### PR TITLE
Indicate there's no song being played back

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <link href="https://afeld.github.io/emoji-css/emoji.css" rel="stylesheet">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/components/empty-playback.css
+++ b/src/components/empty-playback.css
@@ -1,6 +1,15 @@
 .emptyPlaybackMessage {
 }
 
-.emptyPlaybackMessage > p:first-child {
+.emptyPlaybackMessage > p:first-of-type {
     font-weight: bold;
+}
+
+.emptyPlaybackMessage > div:first-of-type {
+    width: 100%;
+    text-align: center;
+}
+
+i[class="em-svg em-thinking_face"] {
+    font-size: xx-large;
 }

--- a/src/components/empty-playback.css
+++ b/src/components/empty-playback.css
@@ -1,0 +1,6 @@
+.emptyPlaybackMessage {
+}
+
+.emptyPlaybackMessage > p:first-child {
+    font-weight: bold;
+}

--- a/src/components/empty-playback.js
+++ b/src/components/empty-playback.js
@@ -1,8 +1,12 @@
 import * as React from 'react';
 
+import './empty-playback.css';
+
 const EmptyPlayback = () => (
-  <div>
-    {"You're not playing anything. Please start playing a song and then refresh the page."}
+  <div className="emptyPlaybackMessage">
+    <p>Nothing found</p>
+    <p>{"When asked for the song you're currently listening to, Spotify said it's got nothing!"}</p>
+    <p>Please start playing a song and then refresh the page.</p>
   </div>
 );
 

--- a/src/components/empty-playback.js
+++ b/src/components/empty-playback.js
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+const EmptyPlayback = () => (
+  <div>
+    {"You're not playing anything. Please start playing a song and then refresh the page."}
+  </div>
+);
+
+export default EmptyPlayback;

--- a/src/components/empty-playback.js
+++ b/src/components/empty-playback.js
@@ -4,6 +4,9 @@ import './empty-playback.css';
 
 const EmptyPlayback = () => (
   <div className="emptyPlaybackMessage">
+    <div>
+      <i className="em-svg em-thinking_face"></i>
+    </div>
     <p>Nothing found</p>
     <p>{"When asked for the song you're currently listening to, Spotify said it's got nothing!"}</p>
     <p>Please start playing a song and then refresh the page.</p>

--- a/src/components/empty-playback.spec.js
+++ b/src/components/empty-playback.spec.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+import EmptyPlayback from './empty-playback';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('Empty playback component', () => {
+  it('just works', () => {
+    shallow(<EmptyPlayback />);
+  });
+});

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import Song from '../components/song';
 import './App.css';
+import EmptyPlayback from '../components/empty-playback';
 
 export default class App extends React.Component {
   constructor(props) {
@@ -23,7 +24,10 @@ export default class App extends React.Component {
 
   getPlaybackData() {
     this.props.spotifyApi.getCurrentPlayback().then(({ body: { item: track } }) => {
-      this.setState({ track });
+      this.setState({
+        track,
+        playback: !!track,
+      });
       this.getAlbum(track.album.id);
       this.getArtist(track.artists[0].id);
     }, this.addError).catch(this.addError);
@@ -61,7 +65,7 @@ export default class App extends React.Component {
 
   render() {
     const {
-      track, album, artist, bestMatch, progress, errors,
+      track, album, artist, bestMatch, progress, errors, playback,
     } = this.state;
     return (
       <div>
@@ -70,6 +74,7 @@ export default class App extends React.Component {
           {errors.map((error, i) => <p key={`error-${i}`}>{error}</p>)}
           <p>Please reload the page to try again</p>
         </div>}
+        {!playback && <EmptyPlayback />}
         <Song
             track={track}
             album={album}

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -23,9 +23,9 @@ export default class App extends React.Component {
   }
 
   getPlaybackData() {
-    this.props.spotifyApi.getCurrentPlayback().then((response) => {
-      if (response.body !== null) {
-        const { body: { item: track } } = response;
+    this.props.spotifyApi.getCurrentPlayback().then(({ body }) => {
+      if (body) {
+        const { item: track } = body;
         this.setState({
           track,
           playback: true,

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -23,12 +23,13 @@ export default class App extends React.Component {
   }
 
   getPlaybackData() {
-    this.props.spotifyApi.getCurrentPlayback().then(({ body: { item: track } }) => {
-      this.setState({
-        track,
-        playback: track !== null,
-      });
-      if (track !== null) {
+    this.props.spotifyApi.getCurrentPlayback().then((response) => {
+      if (response.body !== null) {
+        const { body: { item: track } } = response;
+        this.setState({
+          track,
+          playback: true,
+        });
         this.getAlbum(track.album.id);
         this.getArtist(track.artists[0].id);
       }

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -26,10 +26,12 @@ export default class App extends React.Component {
     this.props.spotifyApi.getCurrentPlayback().then(({ body: { item: track } }) => {
       this.setState({
         track,
-        playback: !!track,
+        playback: track !== null,
       });
-      this.getAlbum(track.album.id);
-      this.getArtist(track.artists[0].id);
+      if (track !== null) {
+        this.getAlbum(track.album.id);
+        this.getArtist(track.artists[0].id);
+      }
     }, this.addError).catch(this.addError);
   }
 
@@ -75,12 +77,12 @@ export default class App extends React.Component {
           <p>Please reload the page to try again</p>
         </div>}
         {!playback && <EmptyPlayback />}
-        <Song
+        {playback && <Song
             track={track}
             album={album}
             artist={artist}
             bestMatch={bestMatch}
-            progress={progress} />
+            progress={progress} />}
       </div>
     );
   }

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -22,10 +22,10 @@ export default class App extends React.Component {
   }
 
   getPlaybackData() {
-    this.props.spotifyApi.getCurrentPlayback().then(({ body: playback }) => {
-      this.setState({ track: playback.item });
-      this.getAlbum(playback.item.album.id);
-      this.getArtist(playback.item.artists[0].id);
+    this.props.spotifyApi.getCurrentPlayback().then(({ body: { item: track } }) => {
+      this.setState({ track });
+      this.getAlbum(track.album.id);
+      this.getArtist(track.artists[0].id);
     }, this.addError).catch(this.addError);
   }
 

--- a/src/containers/App.spec.js
+++ b/src/containers/App.spec.js
@@ -63,6 +63,10 @@ describe('App container', () => {
       expect(backend.getCredits.mock.calls).toEqual([['AL1']]);
     });
 
+    it('displays Song', () => {
+      expect(wrapper.find('Song').length).toEqual(1);
+    });
+
     it('unsubscribes from credits observable', () => {
       wrapper.unmount();
       expect(unsubscribe.mock.calls.length).toEqual(1);

--- a/src/containers/App.spec.js
+++ b/src/containers/App.spec.js
@@ -83,9 +83,7 @@ describe('App container', () => {
   describe('finds NO playback data', () => {
     const mockApi = {
       getCurrentPlayback: jest.fn(() => Promise.resolve({
-        body: {
-          item: null,
-        },
+        body: null,
       })),
       getArtist: jest.fn(),
       getAlbum: jest.fn(),

--- a/src/containers/App.spec.js
+++ b/src/containers/App.spec.js
@@ -106,6 +106,10 @@ describe('App container', () => {
       expect(mockApi.getCurrentPlayback.mock.calls.length).toBe(1);
     });
 
+    it('displays EmptyPlayback component', () => {
+      expect(wrapper.find('EmptyPlayback').length).toBe(1);
+    });
+
     it('does NOT get album', () => {
       expect(mockApi.getAlbum).not.toHaveBeenCalled();
     });

--- a/src/containers/App.spec.js
+++ b/src/containers/App.spec.js
@@ -43,12 +43,19 @@ describe('App container', () => {
       getCredits: jest.fn(() => observable),
     };
 
-    const wrapper = shallow(<App
-        spotifyApi={mockApi}
-        backend={backend} />);
+    let wrapper;
+    beforeAll(() => {
+      wrapper = shallow(<App
+          spotifyApi={mockApi}
+          backend={backend} />);
+    });
 
     it('Calls #getCurrentPlayback on mount', () => {
       expect(mockApi.getCurrentPlayback.mock.calls.length).toBe(1);
+    });
+
+    it('hides EmptyPlayback component', () => {
+      expect(wrapper.update().find('EmptyPlayback').length).toBe(0);
     });
 
     it('gets album', () => {
@@ -64,7 +71,7 @@ describe('App container', () => {
     });
 
     it('displays Song', () => {
-      expect(wrapper.find('Song').length).toEqual(1);
+      expect(wrapper.update().find('Song').length).toEqual(1);
     });
 
     it('unsubscribes from credits observable', () => {
@@ -83,35 +90,37 @@ describe('App container', () => {
       getArtist: jest.fn(),
       getAlbum: jest.fn(),
     };
-    const unsubscribe = jest.fn();
-    const observable = Rx.Observable.create((observer) => {
-      observer.next({
-        progress: 0,
-        bestMatch: {
-          tracks: [{
-            composers: [],
-            producers: [],
-            credits: {},
-          }],
-        },
-      });
-      observer.complete();
-      return unsubscribe;
-    });
     const backend = {
-      getCredits: jest.fn(() => observable),
+      getCredits: jest.fn(),
     };
 
-    const wrapper = shallow(<App
-        spotifyApi={mockApi}
-        backend={backend} />);
+    let wrapper;
+    let errorsSpy;
+    beforeAll(() => {
+      wrapper = shallow(<App
+          spotifyApi={mockApi}
+          backend={backend} />);
+      errorsSpy = jest.spyOn(App.prototype, 'addError');
+    });
 
     it('Calls #getCurrentPlayback on mount', () => {
       expect(mockApi.getCurrentPlayback.mock.calls.length).toBe(1);
     });
 
     it('displays EmptyPlayback component', () => {
-      expect(wrapper.find('EmptyPlayback').length).toBe(1);
+      expect(wrapper.update().find('EmptyPlayback').length).toBe(1);
+    });
+
+    it('hides errors', () => {
+      expect(wrapper.update().find('div[className="errors-div"]').length).toBe(0);
+    });
+
+    it('does not add errors', () => {
+      expect(errorsSpy).not.toHaveBeenCalled();
+    });
+
+    it('hides Song', () => {
+      expect(wrapper.update().find('Song').length).toEqual(0);
     });
 
     it('does NOT get album', () => {

--- a/src/containers/App.spec.js
+++ b/src/containers/App.spec.js
@@ -68,4 +68,54 @@ describe('App container', () => {
       expect(unsubscribe.mock.calls.length).toEqual(1);
     });
   });
+
+  describe('finds NO playback data', () => {
+    const mockApi = {
+      getCurrentPlayback: jest.fn(() => Promise.resolve({
+        body: {
+          item: null,
+        },
+      })),
+      getArtist: jest.fn(),
+      getAlbum: jest.fn(),
+    };
+    const unsubscribe = jest.fn();
+    const observable = Rx.Observable.create((observer) => {
+      observer.next({
+        progress: 0,
+        bestMatch: {
+          tracks: [{
+            composers: [],
+            producers: [],
+            credits: {},
+          }],
+        },
+      });
+      observer.complete();
+      return unsubscribe;
+    });
+    const backend = {
+      getCredits: jest.fn(() => observable),
+    };
+
+    const wrapper = shallow(<App
+        spotifyApi={mockApi}
+        backend={backend} />);
+
+    it('Calls #getCurrentPlayback on mount', () => {
+      expect(mockApi.getCurrentPlayback.mock.calls.length).toBe(1);
+    });
+
+    it('does NOT get album', () => {
+      expect(mockApi.getAlbum).not.toHaveBeenCalled();
+    });
+
+    it('does NOT get artist', () => {
+      expect(mockApi.getArtist).not.toHaveBeenCalled();
+    });
+
+    it('does NOT get credits', () => {
+      expect(backend.getCredits).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
The [endpoint](https://beta.developer.spotify.com/documentation/web-api/reference/player/get-information-about-the-users-current-playback/) to get the current song being played can return a `null` body (see section __Response Format__).

Previous to this PR a red div indicating an error showed

![image](https://user-images.githubusercontent.com/15470487/40244244-5a7714d6-5a90-11e8-8043-2e36226c70cd.png)

With this PR, a message that describes this situation will be shown

![image](https://user-images.githubusercontent.com/15470487/40244267-6d460eb4-5a90-11e8-993a-43d7568a5018.png)