### PR TITLE
Test for the correct element to be present

### DIFF
--- a/src/components/collaborator.spec.js
+++ b/src/components/collaborator.spec.js
@@ -12,7 +12,7 @@ describe('Collaborator component', () => {
       roles={['R1', 'R2']} />);
 
   it('shows name', () => {
-    expect(wrapper.find('h5[className="collaboratorName"]')).toHaveLength(1);
+    expect(wrapper.find('h3[className="collaboratorName"]')).toHaveLength(1);
   });
 
   it('shows roles', () => {


### PR DESCRIPTION
When styles were revised, the unit test that checks for `h5` element to contain the collaborator name was not changed.