### PR TITLE
Not break if artist has no images

### DIFF
--- a/src/components/banner.js
+++ b/src/components/banner.js
@@ -23,7 +23,7 @@ const Banner = ({ src, className, children }) => {
 Banner.propTypes = {
   children: PropTypes.array.isRequired,
   className: PropTypes.string,
-  src: PropTypes.string.isRequired,
+  src: PropTypes.string,
 };
 
 export default Banner;

--- a/src/components/song.js
+++ b/src/components/song.js
@@ -33,10 +33,12 @@ const Song = ({
     return 'with-credits';
   })();
 
+  const artistImg = artist && artist.images.length ? artist.images[0].url : undefined;
+
   return <article>
     {track && artist && album &&
     <Banner
-        src={artist.images[0].url}
+        src={artistImg}
         className="content">
       <Cover
           album={album}

--- a/src/components/song.spec.js
+++ b/src/components/song.spec.js
@@ -6,7 +6,7 @@ import Song from './song';
 
 const track = { artists: [{}] };
 const credits = { composers: [], producers: [], credits: {} };
-const artist = { images: [{}] };
+const artist = { images: [{ url: 'ImgUrl' }] };
 const album = { release_date: '', images: [{}] };
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -44,7 +44,7 @@ describe('Song component', () => {
       album,
       artist,
     });
-    expect(wrapper.find('Banner')).toHaveLength(1);
+    expect(wrapper.find('Banner').prop('src')).toEqual('ImgUrl');
   });
 
   it('displays big progress indicator', () => {

--- a/src/components/song.spec.js
+++ b/src/components/song.spec.js
@@ -12,7 +12,10 @@ const album = { release_date: '', images: [{}] };
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('Song component', () => {
-  const wrapper = shallow(<Song />);
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(<Song />);
+  });
 
   it('hides composers list', () => {
     expect(wrapper.find('JointList[className="composers"]')).toHaveLength(0);

--- a/src/components/song.spec.js
+++ b/src/components/song.spec.js
@@ -47,6 +47,15 @@ describe('Song component', () => {
     expect(wrapper.find('Banner').prop('src')).toEqual('ImgUrl');
   });
 
+  it('does not break when artist has no images', () => {
+    wrapper.setProps({
+      track,
+      artist: { images: [] },
+      album,
+    });
+    expect(wrapper.find('Banner').prop('src')).toBeUndefined();
+  });
+
   it('displays big progress indicator', () => {
     wrapper.setProps({
       bestMatch: credits,


### PR DESCRIPTION
Some artists have no images, such as [Parxe](https://open.spotify.com/artist/03QYGPSAXyWnSOCVMcRxNi).

In dev mode, it breaks:
![image](https://user-images.githubusercontent.com/15470487/40260888-5404d5bc-5acb-11e8-93f0-b9cff67b0b24.png)

In production you just see blank!

This PR checks for this to jut show nothing in place of the artist image:
![image](https://user-images.githubusercontent.com/15470487/40260918-80eeb994-5acb-11e8-9de6-f91102aa8115.png)
