### PR TITLE
Hide the nothing found sign with the initial state of the component

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -9,7 +9,7 @@ export default class App extends React.Component {
   constructor(props) {
     super(props);
     this.addError = this.addError.bind(this);
-    this.state = { errors: [] };
+    this.state = { errors: [], playback: true };
   }
 
   componentDidMount() {
@@ -32,6 +32,8 @@ export default class App extends React.Component {
         });
         this.getAlbum(track.album.id);
         this.getArtist(track.artists[0].id);
+      } else {
+        this.setState({ playback: false });
       }
     }, this.addError).catch(this.addError);
   }


### PR DESCRIPTION
The no found sign (introduced with https://github.com/pedro-otero/crews/pull/1) briefly flashed before loading the song. This PR addressed that by setting an initial state for the `playback` variable, instead of not defining it, and change it when necessary.