### PR TITLE
Refactor Cover properties

### DIFF
--- a/src/components/album/album.js
+++ b/src/components/album/album.js
@@ -17,8 +17,9 @@ export const Album = ({ artist, album, search }) => {
         src={artistImg}
         className="content">
       <Cover
-          album={album}
+          src={album.images[0].url}
           imageClass="albumCover"
+          year={album.release_date.substring(0, 4)}
           yearClass="albumYear" />
       <div>
         <Label

--- a/src/components/album/album.spec.js
+++ b/src/components/album/album.spec.js
@@ -13,7 +13,7 @@ describe('Album component', () => {
 
   it('renders banner', () => {
     const wrapper = shallow(<Album
-        album={{ artists: [{}] }}
+        album={{ artists: [{}], images: [{}], release_date: '' }}
         artist={{ images: [{}] }} />);
     expect(wrapper.find('Banner').length).toEqual(1);
   });

--- a/src/components/cover/cover.js
+++ b/src/components/cover/cover.js
@@ -4,29 +4,28 @@ import PropTypes from 'prop-types';
 import './cover.css';
 
 const Cover = ({
-  album: {
-    images,
-    release_date: releaseDate,
-  },
+  src,
+  year,
   imageClass,
   yearClass,
 }) => {
   const jointImageClass = `image${imageClass ? ` ${imageClass}` : ''}`;
   const jointYearClass = `year${yearClass ? ` ${yearClass}` : ''}`;
-  const imageStyle = { backgroundImage: `url(${images[0].url})` };
+  const imageStyle = { backgroundImage: `url(${src})` };
 
   return <div
       className={jointImageClass}
       style={imageStyle}>
     <span className={jointYearClass}>
-      {releaseDate.substring(0, 4)}
+      {year}
     </span>
   </div>;
 };
 
 Cover.propTypes = {
-  album: PropTypes.object.isRequired,
   imageClass: PropTypes.string,
+  src: PropTypes.string.isRequired,
+  year: PropTypes.string.isRequired,
   yearClass: PropTypes.string,
 };
 

--- a/src/components/cover/cover.spec.js
+++ b/src/components/cover/cover.spec.js
@@ -8,25 +8,31 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe('Cover', () => {
   it('displays album cover', () => {
-    const wrapper = shallow(<Cover album={{ images: [{ url: 'img.jpg' }], release_date: '2004' }} />);
+    const wrapper = shallow(<Cover
+        src='img.jpg'
+        year='2004' />);
     expect(wrapper.find('div[className="image"]').length).toEqual(1);
   });
 
   it('displays album cover with applied class for image', () => {
     const wrapper = shallow(<Cover
-        album={{ images: [{ url: 'img.jpg' }], release_date: '2004' }}
+        src='img.jpg'
+        year='2004'
         imageClass="someClass" />);
     expect(wrapper.find('div[className="image someClass"]').length).toEqual(1);
   });
 
   it('displays year', () => {
-    const wrapper = shallow(<Cover album={{ images: [{ url: 'img.jpg' }], release_date: '2004' }} />);
+    const wrapper = shallow(<Cover
+        src='img.jpg'
+        year='2004' />);
     expect(wrapper.find('span[className="year"]').length).toEqual(1);
   });
 
   it('displays year with applied class for year label', () => {
     const wrapper = shallow(<Cover
-        album={{ images: [{ url: 'img.jpg' }], release_date: '2004' }}
+        src='img.jpg'
+        year='2004'
         yearClass="someClass" />);
     expect(wrapper.find('span[className="year someClass"]').length).toEqual(1);
   });

--- a/src/components/track-details/track-details.js
+++ b/src/components/track-details/track-details.js
@@ -47,9 +47,10 @@ export const TrackDetails = ({
           to={`/album/${album.id}`}
           className="RR-link">
         <Cover
-            album={album}
-            imageClass="albumCover"
-            yearClass="albumYear" />
+          src={album.images[0].url}
+          imageClass="albumCover"
+          year={album.release_date.substring(0, 4)}
+          yearClass="albumYear" />
       </Link>
       <div>
         <Label


### PR DESCRIPTION
No longer requires an album, just the separate properties it uses from it.

Related to #21 