### PR TITLE
Allow single line multiprop component declarations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,11 @@
       "error"
     ],
     "react/jsx-max-props-per-line": [
-      "error"
+      "error",
+      {
+        "maximum": 1,
+        "when": "multiline"
+      }
     ],
     "react/jsx-first-prop-new-line":[
       "error",

--- a/src/components/root.js
+++ b/src/components/root.js
@@ -53,19 +53,9 @@ class Root extends React.Component {
       <Router>
         <span>
           <Errors />
-          <Route
-              exact
-              path="/"
-              render={this.getPlaybackData}
-          />
-          <Route
-              path="/track/:id"
-              render={this.getTrack}
-          />
-          <Route
-              path="/album/:id"
-              render={this.getAlbum}
-          />
+          <Route exact path="/" render={this.getPlaybackData} />
+          <Route path="/track/:id" render={this.getTrack} />
+          <Route path="/album/:id" render={this.getAlbum} />
         </span>
       </Router>
     </Provider>;


### PR DESCRIPTION
Change eslint rule to allow tags with multiple properties to be declared in a single line. Will update components to leverage this new rule config as it appears convenient for every change.