### PR TITLE
Not overwrite credits

### DIFF
--- a/src/redux/tracks.js
+++ b/src/redux/tracks.js
@@ -27,9 +27,6 @@ function trackToState(track) {
     artistId: track.artists[0].id,
     artist: track.artists[0].name,
     duration,
-    composers: [],
-    producers: [],
-    credits: {},
   };
 }
 

--- a/src/user.js
+++ b/src/user.js
@@ -34,6 +34,7 @@ export default (ApiClass, window) => ({
     return CustomApi({
       redirectUri: window.location.origin,
       clientId: process.env.REACT_APP_SPOTIFY_CLIENT_ID,
+      throttle: process.env.REACT_APP_SPOTIFY_THROTTLE,
     });
   },
 });


### PR DESCRIPTION
Not set empty objects for credits info on tracks. If such objects are undefined, the components that display them are already handling them with default props.

This fixes the issue that arises when the result of a search arrives before the spotify track. When this happens the latter overwrites the info set by the former.