### PR TITLE
Not overwrite credits

### DIFF
--- a/src/redux/tracks.js
+++ b/src/redux/tracks.js
@@ -27,9 +27,6 @@ function trackToState(track) {
     artistId: track.artists[0].id,
     artist: track.artists[0].name,
     duration,
-    composers: [],
-    producers: [],
-    credits: {},
   };
 }
 


### PR DESCRIPTION
Not set empty objects for credits info on tracks. If such objects are undefined, the components that display them are already handling them with default props.

This fixes the issue that arises when the result of a search arrives before the spotify track. When this happens the latter overwrites the info set by the former.