### PR TITLE
Reduce thunks scope

### DIFF
--- a/src/components/album-container/album-container.js
+++ b/src/components/album-container/album-container.js
@@ -6,11 +6,11 @@ import { loadAlbum, stopAlbumSearch } from '../../redux/albums';
 import { clearErrors } from '../../redux/errors';
 import Album from '../album/album';
 import { loadSearchResult } from '../../redux/actions/backend';
+import { loadArtist } from '../../redux/artists';
 
 export class AlbumContainer extends React.Component {
   componentDidMount() {
-    this.props.clearErrors();
-    this.props.loadAlbum();
+    this.props.load();
   }
 
   componentWillUnmount() {
@@ -45,7 +45,7 @@ AlbumContainer.propTypes = {
   album: PropTypes.object,
   artist: PropTypes.object,
   clearErrors: PropTypes.func,
-  loadAlbum: PropTypes.func,
+  load: PropTypes.func,
   stopAlbumSearch: PropTypes.func,
   tracks: PropTypes.array,
 };
@@ -60,9 +60,11 @@ const mapStateToProps = ({ tracks, albums, artists }, { albumId }) => {
 };
 
 const mapDispatchToProps = (dispatch, { albumId }) => ({
-  clearErrors: () => dispatch(clearErrors()),
-  loadAlbum: () => {
-    dispatch(loadAlbum(albumId));
+  load: () => {
+    dispatch(clearErrors());
+    dispatch(loadAlbum(albumId)).then(({ artists: [{ id: artistId }] }) => {
+      dispatch(loadArtist(artistId));
+    });
     dispatch(loadSearchResult(albumId));
   },
   stopAlbumSearch: () => dispatch(stopAlbumSearch(albumId)),

--- a/src/components/album-container/album-container.js
+++ b/src/components/album-container/album-container.js
@@ -62,7 +62,7 @@ const mapStateToProps = ({ tracks, albums, artists }, { albumId }) => {
 const mapDispatchToProps = (dispatch, { albumId }) => ({
   load: () => {
     dispatch(clearErrors());
-    dispatch(loadAlbum(albumId)).then(({ artists: [{ id: artistId }] }) => {
+    dispatch(loadAlbum(albumId)).then(({ artistId }) => {
       dispatch(loadArtist(artistId));
     });
     dispatch(loadSearchResult(albumId));

--- a/src/components/track-container/track-container.js
+++ b/src/components/track-container/track-container.js
@@ -7,7 +7,7 @@ import { loadAlbum, stopAlbumSearch } from '../../redux/albums';
 import TrackDetails from '../track-details/track-details';
 import { clearErrors } from '../../redux/errors';
 import { loadSearchResult } from '../../redux/actions/backend';
-import {loadArtist} from "../../redux/artists";
+import { loadArtist } from '../../redux/artists';
 
 export class TrackContainer extends React.Component {
   componentDidMount() {
@@ -70,7 +70,7 @@ const mapStateToProps = ({ tracks, albums, artists }, { trackId }) => {
 const mapDispatchToProps = (dispatch, { trackId }) => ({
   load: () => {
     dispatch(clearErrors());
-    dispatch(loadTrack(trackId)).then(({ album: { id: albumId }, artists: [{ id: artistId }] }) => {
+    dispatch(loadTrack(trackId)).then(({ albumId, artistId }) => {
       dispatch(loadSearchResult(albumId));
       dispatch(loadAlbum(albumId));
       dispatch(loadArtist(artistId));

--- a/src/components/track-container/track-container.js
+++ b/src/components/track-container/track-container.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { loadTrack } from '../../redux/tracks';
-import { stopAlbumSearch } from '../../redux/albums';
+import { loadAlbum, stopAlbumSearch } from '../../redux/albums';
 import TrackDetails from '../track-details/track-details';
 import { clearErrors } from '../../redux/errors';
+import { loadSearchResult } from '../../redux/actions/backend';
 
 export class TrackContainer extends React.Component {
   componentDidMount() {
-    this.props.clearErrors();
-    this.props.loadTrack();
+    this.props.load();
   }
 
   componentWillUnmount() {
@@ -52,7 +52,7 @@ TrackContainer.propTypes = {
   album: PropTypes.object,
   artist: PropTypes.object,
   clearErrors: PropTypes.func,
-  loadTrack: PropTypes.func,
+  load: PropTypes.func,
   stopAlbumSearch: PropTypes.func,
   track: PropTypes.object,
 };
@@ -67,8 +67,13 @@ const mapStateToProps = ({ tracks, albums, artists }, { trackId }) => {
 };
 
 const mapDispatchToProps = (dispatch, { trackId }) => ({
-  clearErrors: () => dispatch(clearErrors()),
-  loadTrack: () => dispatch(loadTrack(trackId)),
+  load: () => {
+    dispatch(clearErrors());
+    dispatch(loadTrack(trackId)).then(({ album: { id: albumId } }) => {
+      dispatch(loadSearchResult(albumId));
+      dispatch(loadAlbum(albumId));
+    });
+  },
   stopAlbumSearch: albumId => dispatch(stopAlbumSearch(albumId)),
 });
 

--- a/src/components/track-container/track-container.js
+++ b/src/components/track-container/track-container.js
@@ -7,6 +7,7 @@ import { loadAlbum, stopAlbumSearch } from '../../redux/albums';
 import TrackDetails from '../track-details/track-details';
 import { clearErrors } from '../../redux/errors';
 import { loadSearchResult } from '../../redux/actions/backend';
+import {loadArtist} from "../../redux/artists";
 
 export class TrackContainer extends React.Component {
   componentDidMount() {
@@ -69,9 +70,10 @@ const mapStateToProps = ({ tracks, albums, artists }, { trackId }) => {
 const mapDispatchToProps = (dispatch, { trackId }) => ({
   load: () => {
     dispatch(clearErrors());
-    dispatch(loadTrack(trackId)).then(({ album: { id: albumId } }) => {
+    dispatch(loadTrack(trackId)).then(({ album: { id: albumId }, artists: [{ id: artistId }] }) => {
       dispatch(loadSearchResult(albumId));
       dispatch(loadAlbum(albumId));
+      dispatch(loadArtist(artistId));
     });
   },
   stopAlbumSearch: albumId => dispatch(stopAlbumSearch(albumId)),

--- a/src/redux/albums.js
+++ b/src/redux/albums.js
@@ -11,10 +11,12 @@ export const loadAlbum = id => (dispatch, getState, { spotifyApi, actions }) => 
   const album = getState().albums[id];
   if (!album || album.failed) {
     dispatch(actions.startAlbumLoad(id));
-    return spotifyApi.getAlbum(id).then((response) => {
-      dispatch(actions.setAlbum(response.body));
-      return response.body;
-    }, () => dispatch(actions.failAlbumLoad(id)));
+    return spotifyApi.getAlbum(id).then(
+      response =>
+        dispatch(actions.setAlbum(response.body)).data,
+      () =>
+        dispatch(actions.failAlbumLoad(id)),
+    );
   }
   return Promise.resolve(album);
 };

--- a/src/redux/albums.js
+++ b/src/redux/albums.js
@@ -1,5 +1,4 @@
 import { updateState } from './helpers';
-import { SET_ARTIST } from './artists';
 
 export const START_ALBUM_LOAD = 'START_ALBUM_LOAD';
 export const SET_ALBUM = 'SET_ALBUM';

--- a/src/redux/albums.js
+++ b/src/redux/albums.js
@@ -11,13 +11,10 @@ export const loadAlbum = id => (dispatch, getState, { spotifyApi, actions }) => 
   const album = getState().albums[id];
   if (!album || album.failed) {
     dispatch(actions.startAlbumLoad(id));
-    return spotifyApi
-      .getAlbum(id).then((response) => {
-        dispatch(actions.setAlbum(response.body));
-        const artistId = response.body.artists[0].id;
-        dispatch(actions.loadArtist(artistId));
-        return response;
-      }, () => dispatch(actions.failAlbumLoad(id)));
+    return spotifyApi.getAlbum(id).then((response) => {
+      dispatch(actions.setAlbum(response.body));
+      return response.body;
+    }, () => dispatch(actions.failAlbumLoad(id)));
   }
   return Promise.resolve(album);
 };

--- a/src/redux/albums.spec.js
+++ b/src/redux/albums.spec.js
@@ -1,6 +1,6 @@
 import { FAIL_ALBUM_LOAD, loadAlbum, reduce, SET_ALBUM, setAlbum, START_ALBUM_LOAD } from './albums';
 
-const dispatch = jest.fn();
+const dispatch = jest.fn(v => v);
 const album = { id: 'AL1', artists: [{ id: 'AR1' }], tracks: { items: [{ id: 'T1' }] } };
 const successApi = {
   getAlbum: jest.fn(() => Promise.resolve({ body: album })),
@@ -11,7 +11,9 @@ const failureApi = {
 const actions = {
   loadArtist: jest.fn(),
   setTrack: jest.fn(),
-  setAlbum: jest.fn(),
+  setAlbum: jest.fn(() => ({
+    data: { id: 'AL1' },
+  })),
   startAlbumLoad: jest.fn(),
   failAlbumLoad: jest.fn(),
 };
@@ -36,7 +38,7 @@ describe('REDUX: Albums', () => {
     });
 
     it('forwards response', () => {
-      expect(response.body).toEqual(album);
+      expect(response.id).toEqual('AL1');
     });
 
     it('calls api method', () => {

--- a/src/redux/albums.spec.js
+++ b/src/redux/albums.spec.js
@@ -47,10 +47,6 @@ describe('REDUX: Albums', () => {
       expect(actions.startAlbumLoad).toHaveBeenCalledWith('AL1');
     });
 
-    it('calls actions.loadArtist', () => {
-      expect(actions.loadArtist).toHaveBeenCalledWith('AR1');
-    });
-
     it('informs load succeded', () => {
       expect(actions.setAlbum).toHaveBeenCalledWith(album);
     });

--- a/src/redux/tracks.js
+++ b/src/redux/tracks.js
@@ -10,14 +10,10 @@ export const loadTrack = id => (dispatch, getState, { spotifyApi, actions }) => 
   const track = getState().tracks[id];
   if (!track || track.failed) {
     dispatch(actions.startTrackLoad(id));
-    return spotifyApi
-      .getTrack(id).then((response) => {
-        dispatch(actions.setTrack(response.body));
-        const albumId = response.body.album.id;
-        dispatch(actions.loadSearchResult(albumId));
-        dispatch(actions.loadAlbum(albumId));
-        return response;
-      }, () => dispatch(actions.failTrackLoad(id)));
+    return spotifyApi.getTrack(id).then((response) => {
+      dispatch(actions.setTrack(response.body));
+      return response.body;
+    }, () => dispatch(actions.failTrackLoad(id)));
   }
   return Promise.resolve(track);
 };

--- a/src/redux/tracks.js
+++ b/src/redux/tracks.js
@@ -10,10 +10,12 @@ export const loadTrack = id => (dispatch, getState, { spotifyApi, actions }) => 
   const track = getState().tracks[id];
   if (!track || track.failed) {
     dispatch(actions.startTrackLoad(id));
-    return spotifyApi.getTrack(id).then((response) => {
-      dispatch(actions.setTrack(response.body));
-      return response.body;
-    }, () => dispatch(actions.failTrackLoad(id)));
+    return spotifyApi.getTrack(id).then(
+      response =>
+        dispatch(actions.setTrack(response.body)).data,
+      () =>
+        dispatch(actions.failTrackLoad(id)),
+    );
   }
   return Promise.resolve(track);
 };

--- a/src/redux/tracks.js
+++ b/src/redux/tracks.js
@@ -1,6 +1,5 @@
 import { updateState } from './helpers';
 import { SET_ALBUM, SET_SEARCH_RESULT } from './albums';
-import { SET_ARTIST } from './artists';
 
 export const START_TRACK_LOAD = 'START_TRACK_LOAD';
 export const SET_TRACK = 'SET_TRACK';

--- a/src/redux/tracks.spec.js
+++ b/src/redux/tracks.spec.js
@@ -1,7 +1,7 @@
 import { FAIL_TRACK_LOAD, loadTrack, reduce, SET_TRACK, setTrack, START_TRACK_LOAD } from './tracks';
 
 describe('REDUX: Tracks', () => {
-  const dispatch = jest.fn();
+  const dispatch = jest.fn(v => v);
   const track = {
     id: 'T1',
     artists: [{ id: 'AR1' }],
@@ -18,7 +18,9 @@ describe('REDUX: Tracks', () => {
   };
   const actions = {
     loadAlbum: jest.fn(),
-    setTrack: jest.fn(),
+    setTrack: jest.fn(() => ({
+      data: { id: 'T1' },
+    })),
     startTrackLoad: jest.fn(),
     failTrackLoad: jest.fn(),
     loadSearchResult: jest.fn(),
@@ -43,7 +45,7 @@ describe('REDUX: Tracks', () => {
     });
 
     it('forwards response', () => {
-      expect(response.body).toEqual(track);
+      expect(response.id).toEqual('T1');
     });
 
     it('calls api method', () => {

--- a/src/redux/tracks.spec.js
+++ b/src/redux/tracks.spec.js
@@ -50,10 +50,6 @@ describe('REDUX: Tracks', () => {
       expect(successApi.getTrack).toHaveBeenCalledWith('T1');
     });
 
-    it('calls actions.loadAlbum', () => {
-      expect(actions.loadAlbum).toHaveBeenCalledWith('AL1');
-    });
-
     it('informs load started', () => {
       expect(actions.startTrackLoad).toHaveBeenCalledWith('T1');
     });


### PR DESCRIPTION
Limit the thunks to load only the entity requested and not trigger more thunks. That's left to the connected components (TrackContainer and AlbumContainer).