### PR TITLE
Thunk helper

### DIFF
--- a/src/redux/albums.js
+++ b/src/redux/albums.js
@@ -1,4 +1,4 @@
-import { updateState } from './helpers';
+import { loadThunk, updateState } from './helpers';
 
 export const START_ALBUM_LOAD = 'START_ALBUM_LOAD';
 export const SET_ALBUM = 'SET_ALBUM';
@@ -6,19 +6,15 @@ export const FAIL_ALBUM_LOAD = 'FAIL_ALBUM_LOAD';
 export const SET_SEARCH_RESULT = 'SET_SEARCH_RESULT';
 export const STOP_ALBUM_SEARCH = 'STOP_ALBUM_SEARCH';
 
-export const loadAlbum = id => (dispatch, getState, { spotifyApi, actions }) => {
-  const album = getState().albums[id];
-  if (!album || album.failed) {
-    dispatch(actions.startAlbumLoad(id));
-    return spotifyApi.getAlbum(id).then(
-      response =>
-        dispatch(actions.setAlbum(response.body)).data,
-      () =>
-        dispatch(actions.failAlbumLoad(id)),
-    );
-  }
-  return Promise.resolve(album);
-};
+export const loadAlbum = id => (dispatch, getState, { spotifyApi, actions }) => loadThunk(
+  id,
+  getState().albums,
+  dispatch,
+  actions.startAlbumLoad,
+  spotifyApi.getAlbum,
+  actions.setAlbum,
+  actions.failAlbumLoad,
+);
 
 export const setAlbum = (album) => {
   const {

--- a/src/redux/artists.js
+++ b/src/redux/artists.js
@@ -1,21 +1,18 @@
-import { updateState } from './helpers';
+import { loadThunk, updateState } from './helpers';
 
 export const START_ARTIST_LOAD = 'START_ARTIST_LOAD';
 export const SET_ARTIST = 'SET_ARTIST';
 export const FAIL_ARTIST_LOAD = 'FAIL_ARTIST_LOAD';
 
-export const loadArtist = id => (dispatch, getState, { spotifyApi, actions }) => {
-  const artist = getState().artists[id];
-  if (!artist || artist.failed) {
-    dispatch(actions.startArtistLoad(id));
-    return spotifyApi
-      .getArtist(id).then((response) => {
-        dispatch(actions.setArtist(response.body));
-        return response;
-      }, () => dispatch(actions.failArtistLoad(id)));
-  }
-  return Promise.resolve(artist);
-};
+export const loadArtist = id => (dispatch, getState, { spotifyApi, actions }) => loadThunk(
+  id,
+  getState().artists,
+  dispatch,
+  actions.startArtistLoad,
+  spotifyApi.getArtist,
+  actions.setArtist,
+  actions.failArtistLoad,
+);
 
 export const setArtist = ({ id, name, images }) => ({
   type: SET_ARTIST,

--- a/src/redux/helpers.js
+++ b/src/redux/helpers.js
@@ -5,3 +5,17 @@ export const updateState = (state, defaultItem) => tracks => tracks.reduce((all,
   );
   return Object.assign({ ...all }, { [track.id]: merged });
 }, state);
+
+export const loadThunk = (id, items, dispatch, start, load, set, fail) => {
+  const item = items[id];
+  if (!item || item.failed) {
+    dispatch(start(id));
+    return load(id).then(
+      response =>
+        dispatch(set(response.body)).data,
+      () =>
+        dispatch(fail(id)),
+    );
+  }
+  return Promise.resolve(item);
+};

--- a/src/redux/tracks.js
+++ b/src/redux/tracks.js
@@ -1,23 +1,19 @@
-import { updateState } from './helpers';
+import { loadThunk, updateState } from './helpers';
 import { SET_ALBUM, SET_SEARCH_RESULT } from './albums';
 
 export const START_TRACK_LOAD = 'START_TRACK_LOAD';
 export const SET_TRACK = 'SET_TRACK';
 export const FAIL_TRACK_LOAD = 'FAIL_TRACK_LOAD';
 
-export const loadTrack = id => (dispatch, getState, { spotifyApi, actions }) => {
-  const track = getState().tracks[id];
-  if (!track || track.failed) {
-    dispatch(actions.startTrackLoad(id));
-    return spotifyApi.getTrack(id).then(
-      response =>
-        dispatch(actions.setTrack(response.body)).data,
-      () =>
-        dispatch(actions.failTrackLoad(id)),
-    );
-  }
-  return Promise.resolve(track);
-};
+export const loadTrack = id => (dispatch, getState, { spotifyApi, actions }) => loadThunk(
+  id,
+  getState().tracks,
+  dispatch,
+  actions.startTrackLoad,
+  spotifyApi.getTrack,
+  actions.setTrack,
+  actions.failTrackLoad,
+);
 
 function trackToState(track) {
   const minutes = Math.floor(track.duration_ms / 60000);


### PR DESCRIPTION
Add a helper to load spotify entities that use the same steps and have a `.failed` property