### PR TITLE
Reduce search thunk scope

### DIFF
--- a/src/redux/playbackInfo.js
+++ b/src/redux/playbackInfo.js
@@ -6,24 +6,11 @@ export const setPlaybackInfo = data => ({
 });
 
 export const loadPlaybackInfo = () => (dispatch, getState, {
-  spotifyApi, actions: {
-    setPlaybackInfo,
-    loadSearchResult,
-    setTrack,
-    loadArtist,
-    loadAlbum,
-    addError,
-  },
+  spotifyApi, actions: { setPlaybackInfo, addError },
 }) => {
   dispatch(setPlaybackInfo('LOADING'));
   return spotifyApi.getMyCurrentPlaybackState().then((response) => {
     dispatch(setPlaybackInfo(response.body));
-    if (response.body) {
-      const albumId = response.body.item.album.id;
-      dispatch(loadSearchResult(albumId));
-      const artistId = response.body.item.artists[0].id;
-      dispatch(loadAlbum(albumId)).then(() => dispatch(loadArtist(artistId)));
-    }
     return response;
   }, () => {
     dispatch(setPlaybackInfo('FAILED'));

--- a/src/redux/playbackInfo.spec.js
+++ b/src/redux/playbackInfo.spec.js
@@ -60,24 +60,12 @@ describe('Playback info', () => {
       expect(successApi.getCurrentPlayback).toHaveBeenCalled();
     });
 
-    it('calls loadSearchResult', () => {
-      expect(actions.loadSearchResult).toHaveBeenCalledWith('AL1');
-    });
-
     it('informs load started', () => {
       expect(actions.setPlaybackInfo).toHaveBeenCalledWith('LOADING');
     });
 
     it('informs load finished', () => {
       expect(actions.setPlaybackInfo).toHaveBeenCalledWith(playbackInfo);
-    });
-
-    it('calls actions.loadArtist', () => {
-      expect(actions.loadArtist).toHaveBeenCalledWith('AR1');
-    });
-
-    it('calls actions.loadAlbum', () => {
-      expect(actions.loadAlbum).toHaveBeenCalledWith('AL1');
     });
 
     afterAll(() => {
@@ -116,18 +104,6 @@ describe('Playback info', () => {
 
     it('informs load finished', () => {
       expect(actions.setPlaybackInfo).toHaveBeenCalledWith(null);
-    });
-
-    it('does not call actions.loadArtist', () => {
-      expect(actions.loadArtist).not.toHaveBeenCalled();
-    });
-
-    it('does not call actions.loadAlbum', () => {
-      expect(actions.loadAlbum).not.toHaveBeenCalled();
-    });
-
-    it('does not call actions.setTrack', () => {
-      expect(actions.setTrack).not.toHaveBeenCalled();
     });
 
     afterAll(clearActionMocks);


### PR DESCRIPTION
Not dispatch any spotify data actions from the search thunk.