### PR TITLE
Fix redirect to current playback

### DIFF
--- a/src/components/album-container/album-container.js
+++ b/src/components/album-container/album-container.js
@@ -55,4 +55,4 @@ const mapDispatchToProps = (dispatch, { albumId }) => ({
   },
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(EntityContainer(AlbumContainer));
+export default connect(mapStateToProps, mapDispatchToProps)(EntityContainer(AlbumContainer, 'albumId'));

--- a/src/components/entity-container/entity-container.js
+++ b/src/components/entity-container/entity-container.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { loadSearchResult } from '../../redux/actions/backend';
 import { clearErrors } from '../../redux/errors';
 
-export default (Component) => {
+export default (Component, mainId) => {
   class Wrapped extends React.Component {
     static propTypes = {
       album: PropTypes.object,
@@ -15,11 +15,18 @@ export default (Component) => {
     };
 
     componentDidMount() {
+      this.callLoad();
+    }
+
+    callLoad() {
       this.props.clearErrors();
       this.props.load();
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prev) {
+      if (prev[mainId] !== this.props[mainId] && !!this.props[mainId]) {
+        this.callLoad();
+      }
       if (this.props.album.id && !this.albumSearch) {
         this.albumSearch = this.props.loadSearchResult(this.props.album.id);
       }

--- a/src/components/entity-container/entity-container.js
+++ b/src/components/entity-container/entity-container.js
@@ -25,6 +25,7 @@ export default (Component, mainId) => {
 
     componentDidUpdate(prev) {
       if (prev[mainId] !== this.props[mainId] && !!this.props[mainId]) {
+        this.stopSearch();
         this.callLoad();
       }
       if (this.props.album.id && !this.albumSearch) {
@@ -33,8 +34,13 @@ export default (Component, mainId) => {
     }
 
     componentWillUnmount() {
+      this.stopSearch();
+    }
+
+    stopSearch() {
       if (this.albumSearch) {
         this.albumSearch.unsubscribe();
+        this.albumSearch = null;
       }
     }
 

--- a/src/components/root.js
+++ b/src/components/root.js
@@ -14,26 +14,10 @@ import TrackContainer from './track-container/track-container';
 import AlbumContainer from './album-container/album-container';
 
 class Root extends React.Component {
-  constructor(props) {
-    super(props);
-    this.getPlaybackData = this.getPlaybackData.bind(this);
-  }
-
   componentWillMount() {
     if (this.props.isAuthenticated) {
       this.props.loadProfile();
     }
-  }
-
-  getPlaybackData() {
-    this.props.clearErrors();
-    this.props.loadPlaybackInfo().then((data) => {
-      if (data.body) {
-        window.location = `/track/${data.body.item.id}`;
-      } else {
-        this.props.addError('Playback stopped. Please start playback and retry.');
-      }
-    });
   }
 
   getAuthUrl() {
@@ -58,13 +42,7 @@ class Root extends React.Component {
       <Router>
         <span>
           <Errors />
-          <TitleBar
-              title="Crews"
-              onLogout={() => {
-            window.localStorage.clear();
-            window.location = '/';
-          }}
-              onAvatarClick={this.getPlaybackData} />
+          <TitleBar title="Crews" />
           <div style={{ position: 'relative' }}>
             <Route exact path="/" component={Home} />
             <Route path="/track/:id" render={({ match }) => <TrackContainer trackId={match.params.id} />} />

--- a/src/components/title-bar/title-bar.js
+++ b/src/components/title-bar/title-bar.js
@@ -46,16 +46,13 @@ const Anchor = styled.a`
 `;
 
 export const TitleBar = ({
-  loading, avatar, name, onLogout, loadPlaybackInfo, history, addError, clearErrors,
+  loading, avatar, name, onLogout, load, history,
 }) => {
   const title = loading ? 'Crews' : name;
   const onAvatarClick = () => {
-    clearErrors();
-    loadPlaybackInfo().then((data) => {
-      if (data.body) {
-        history.push(`/track/${data.body.item.id}`);
-      } else {
-        addError('Playback stopped. Please start playback and retry.');
+    load().then((trackId) => {
+      if (trackId) {
+        history.push(`/track/${trackId}`);
       }
     });
   };
@@ -71,10 +68,9 @@ export const TitleBar = ({
 };
 
 TitleBar.propTypes = {
-  addError: PropTypes.func,
   avatar: PropTypes.string,
   history: PropTypes.object,
-  loadPlaybackInfo: PropTypes.func,
+  load: PropTypes.func,
   loading: PropTypes.bool,
   name: PropTypes.string,
   onLogout: PropTypes.func,
@@ -84,9 +80,16 @@ const mapStateToProps = ({ user: { profile: { loading, avatar, name } } }) =>
   ({ loading, avatar, name });
 
 const mapDispatchToProps = dispatch => ({
-  loadPlaybackInfo: () => dispatch(loadPlaybackInfo()),
-  addError: message => dispatch(addError(message)),
-  clearErrors: () => dispatch(clearErrors()),
+  load: () => {
+    dispatch(clearErrors());
+    return dispatch(loadPlaybackInfo()).then((data) => {
+      if (data.body) {
+        return data.body.item.id;
+      }
+      dispatch(addError('Playback stopped. Please start playback and retry.'));
+      return null;
+    });
+  },
 });
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TitleBar));

--- a/src/components/title-bar/title-bar.js
+++ b/src/components/title-bar/title-bar.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { loadPlaybackInfo } from '../../redux/playbackInfo';
+import { addError } from '../../redux/errors';
 
 const BORDER_COLOR = 'rgba(128, 128, 128, 0.2)';
 
@@ -45,7 +46,7 @@ const Anchor = styled.a`
 `;
 
 export const TitleBar = ({
-  loading, avatar, name, onLogout, loadPlaybackInfo, history,
+  loading, avatar, name, onLogout, loadPlaybackInfo, history, addError,
 }) => {
   const title = loading ? 'Crews' : name;
   const onAvatarClick = () => {
@@ -53,7 +54,7 @@ export const TitleBar = ({
       if (data.body) {
         history.push(`/track/${data.body.item.id}`);
       } else {
-        this.props.addError('Playback stopped. Please start playback and retry.');
+        addError('Playback stopped. Please start playback and retry.');
       }
     });
   };
@@ -69,6 +70,7 @@ export const TitleBar = ({
 };
 
 TitleBar.propTypes = {
+  addError: PropTypes.func,
   avatar: PropTypes.string,
   history: PropTypes.object,
   loadPlaybackInfo: PropTypes.func,
@@ -82,6 +84,7 @@ const mapStateToProps = ({ user: { profile: { loading, avatar, name } } }) =>
 
 const mapDispatchToProps = dispatch => ({
   loadPlaybackInfo: () => dispatch(loadPlaybackInfo()),
+  addError: message => dispatch(addError(message)),
 });
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TitleBar));

--- a/src/components/title-bar/title-bar.js
+++ b/src/components/title-bar/title-bar.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { loadPlaybackInfo } from '../../redux/playbackInfo';
-import { addError } from '../../redux/errors';
+import { addError, clearErrors } from '../../redux/errors';
 
 const BORDER_COLOR = 'rgba(128, 128, 128, 0.2)';
 
@@ -46,10 +46,11 @@ const Anchor = styled.a`
 `;
 
 export const TitleBar = ({
-  loading, avatar, name, onLogout, loadPlaybackInfo, history, addError,
+  loading, avatar, name, onLogout, loadPlaybackInfo, history, addError, clearErrors,
 }) => {
   const title = loading ? 'Crews' : name;
   const onAvatarClick = () => {
+    clearErrors();
     loadPlaybackInfo().then((data) => {
       if (data.body) {
         history.push(`/track/${data.body.item.id}`);
@@ -85,6 +86,7 @@ const mapStateToProps = ({ user: { profile: { loading, avatar, name } } }) =>
 const mapDispatchToProps = dispatch => ({
   loadPlaybackInfo: () => dispatch(loadPlaybackInfo()),
   addError: message => dispatch(addError(message)),
+  clearErrors: () => dispatch(clearErrors()),
 });
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TitleBar));

--- a/src/components/title-bar/title-bar.js
+++ b/src/components/title-bar/title-bar.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { loadPlaybackInfo } from '../../redux/playbackInfo';
 
 const BORDER_COLOR = 'rgba(128, 128, 128, 0.2)';
 
@@ -43,9 +45,18 @@ const Anchor = styled.a`
 `;
 
 export const TitleBar = ({
-  loading, avatar, name, onAvatarClick, onLogout,
+  loading, avatar, name, onLogout, loadPlaybackInfo, history,
 }) => {
   const title = loading ? 'Crews' : name;
+  const onAvatarClick = () => {
+    loadPlaybackInfo().then((data) => {
+      if (data.body) {
+        history.push(`/track/${data.body.item.id}`);
+      } else {
+        this.props.addError('Playback stopped. Please start playback and retry.');
+      }
+    });
+  };
   return <Row>
     <Anchor onClick={onAvatarClick}>
       <Avatar src={avatar} />
@@ -59,13 +70,18 @@ export const TitleBar = ({
 
 TitleBar.propTypes = {
   avatar: PropTypes.string,
+  history: PropTypes.object,
+  loadPlaybackInfo: PropTypes.func,
   loading: PropTypes.bool,
   name: PropTypes.string,
-  onAvatarClick: PropTypes.func,
   onLogout: PropTypes.func,
 };
 
 const mapStateToProps = ({ user: { profile: { loading, avatar, name } } }) =>
   ({ loading, avatar, name });
 
-export default connect(mapStateToProps)(TitleBar);
+const mapDispatchToProps = dispatch => ({
+  loadPlaybackInfo: () => dispatch(loadPlaybackInfo()),
+});
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TitleBar));

--- a/src/components/track-container/track-container.js
+++ b/src/components/track-container/track-container.js
@@ -62,4 +62,4 @@ const mapDispatchToProps = (dispatch, { trackId }) => ({
   },
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(EntityContainer(TrackContainer));
+export default connect(mapStateToProps, mapDispatchToProps)(EntityContainer(TrackContainer, 'trackId'));


### PR DESCRIPTION
Remove current playback loading logic from root component and move it to TitleBar.
Fix EntityContainer lifecycles so actions to start/stop searches and loading of entities works across route changes (that trigger `componentDidUpdate` instead of `componentDidMount`.