### PR TITLE
View actions

### DIFF
--- a/src/components/album-container/album-container.js
+++ b/src/components/album-container/album-container.js
@@ -4,8 +4,7 @@ import { connect } from 'react-redux';
 
 import Album from 'components/Album';
 import EntityContainer from 'components/EntityContainer';
-import { loadAlbum } from 'state/albums';
-import { loadArtist } from 'state/artists';
+import { viewAlbum } from 'state/view';
 
 export class AlbumContainer extends React.Component {
   render() {
@@ -48,11 +47,7 @@ const mapStateToProps = ({ tracks, albums, artists }, { albumId }) => {
 };
 
 const mapDispatchToProps = (dispatch, { albumId }) => ({
-  load: () => {
-    dispatch(loadAlbum(albumId)).then(({ artistId }) => {
-      dispatch(loadArtist(artistId));
-    });
-  },
+  load: () => dispatch(viewAlbum(albumId)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(EntityContainer(AlbumContainer, 'albumId'));

--- a/src/components/track-container/track-container.js
+++ b/src/components/track-container/track-container.js
@@ -4,9 +4,7 @@ import { connect } from 'react-redux';
 
 import TrackDetails from 'components/TrackDetails';
 import EntityContainer from 'components/EntityContainer';
-import { loadTrack } from 'state/tracks';
-import { loadAlbum } from 'state/albums';
-import { loadArtist } from 'state/artists';
+import { viewTrack } from 'state/view';
 
 export class TrackContainer extends React.Component {
   render() {
@@ -54,12 +52,7 @@ const mapStateToProps = ({ tracks, albums, artists }, { trackId }) => {
 };
 
 const mapDispatchToProps = (dispatch, { trackId }) => ({
-  load: () => {
-    dispatch(loadTrack(trackId)).then(({ albumId, artistId }) => {
-      dispatch(loadAlbum(albumId));
-      dispatch(loadArtist(artistId));
-    });
-  },
+  load: () => dispatch(viewTrack(trackId)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(EntityContainer(TrackContainer, 'trackId'));

--- a/src/redux/view.js
+++ b/src/redux/view.js
@@ -6,3 +6,10 @@ export const viewTrack = trackId =>
       dispatch(loadArtist(artistId));
       return track;
     });
+
+export const viewAlbum = albumId =>
+  (dispatch, getState, { actions: { loadTrack, loadAlbum, loadArtist } }) =>
+    dispatch(loadAlbum(albumId)).then((album) => {
+      dispatch(loadArtist(album.artistId));
+      return album;
+    });

--- a/src/redux/view.js
+++ b/src/redux/view.js
@@ -1,0 +1,8 @@
+export const viewTrack = trackId =>
+  (dispatch, getState, { actions: { loadTrack, loadAlbum, loadArtist } }) =>
+    dispatch(loadTrack(trackId)).then((track) => {
+      const { artistId, albumId } = track;
+      dispatch(loadAlbum(albumId));
+      dispatch(loadArtist(artistId));
+      return track;
+    });

--- a/src/redux/view.spec.js
+++ b/src/redux/view.spec.js
@@ -1,4 +1,4 @@
-import { viewTrack } from './view';
+import { viewTrack, viewAlbum } from './view';
 
 describe('View actions', () => {
   describe('View track', () => {
@@ -20,6 +20,27 @@ describe('View actions', () => {
 
     it('calls loadAlbum', () => {
       expect(loadAlbum).toBeCalledWith('L1');
+    });
+
+    it('calls loadArtist', () => {
+      expect(loadArtist).toBeCalledWith('R1');
+    });
+  });
+
+  describe('View album', () => {
+    const album = { artistId: 'R1' };
+    const dispatch = jest.fn(() => Promise.resolve(album));
+    const mocks = [jest.fn(), jest.fn()];
+    const [loadAlbum, loadArtist] = mocks;
+    const actions = { loadAlbum, loadArtist };
+
+    beforeAll(() => {
+      const thunk = viewAlbum('A1');
+      thunk(dispatch, () => ({}), { actions });
+    });
+
+    it('calls loadAlbum', () => {
+      expect(loadAlbum).toBeCalledWith('A1');
     });
 
     it('calls loadArtist', () => {

--- a/src/redux/view.spec.js
+++ b/src/redux/view.spec.js
@@ -1,0 +1,29 @@
+import { viewTrack } from './view';
+
+describe('View actions', () => {
+  describe('View track', () => {
+    const track = { albumId: 'L1', artistId: 'R1' };
+    const dispatch = jest.fn(() => Promise.resolve(track));
+    const loadTrack = jest.fn(() => track);
+    const mocks = [jest.fn(), jest.fn()];
+    const [loadAlbum, loadArtist] = mocks;
+    const actions = { loadTrack, loadAlbum, loadArtist };
+
+    beforeAll(() => {
+      const thunk = viewTrack('T1');
+      thunk(dispatch, () => ({}), { actions });
+    });
+
+    it('calls loadTrack', () => {
+      expect(loadTrack).toBeCalledWith('T1');
+    });
+
+    it('calls loadAlbum', () => {
+      expect(loadAlbum).toBeCalledWith('L1');
+    });
+
+    it('calls loadArtist', () => {
+      expect(loadArtist).toBeCalledWith('R1');
+    });
+  });
+});


### PR DESCRIPTION
Introduces view actions that trigger the actions necessary to view albums and tracks, removing this code from the album and track containers, where they could not be easily tested